### PR TITLE
fix: add fallback on timer fail load

### DIFF
--- a/assets/refresh.svg
+++ b/assets/refresh.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.99902 16C3.99902 9.37258 9.37161 4 15.999 4C22.6264 4 27.999 9.37258 27.999 16C27.999 22.6274 22.6264 28 15.999 28C12.592 28 9.51669 26.5802 7.33236 24.3" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1.33396 14.6656L3.98729 17.9189L6.64062 14.6656" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/css/constants.css
+++ b/css/constants.css
@@ -168,3 +168,24 @@ html[data-theme='dark'] {
         background-position: 440px
     }
 }
+
+
+@keyframes shine-lines-timer-days {
+    0% {
+        background-position: -114px
+    }
+
+    100% {
+        background-position: 114px
+    }
+}
+
+@keyframes shine-lines-timer-item {
+    0% {
+        background-position: -38px
+    }
+
+    100% {
+        background-position: 38px
+    }
+}

--- a/css/constants.css
+++ b/css/constants.css
@@ -169,7 +169,6 @@ html[data-theme='dark'] {
     }
 }
 
-
 @keyframes shine-lines-timer-days {
     0% {
         background-position: -114px

--- a/css/dns.css
+++ b/css/dns.css
@@ -2038,22 +2038,22 @@ html[data-theme='dark'] .mobile-menu #moonLottieBlack {
 .in {
     opacity: 1;
 }
-.failedTimerIconContainer{
+.failed-timer-icon-container{
     background: unset;
     width: max-content;
     margin: 0 auto;
     padding: 0;
 }
 
-.failedTimerIconContainer:hover{
+.failed-timer-icon-container:hover{
     background: unset;
 }
 
-.failedTimerIconContainer:hover .failedTimerIcon{
+.failed-timer-icon-container:hover .failed-timer-icon{
     background-color: var(--accent-hover);
 }
 
-.failedTimerIcon{
+.failed-timer-icon{
     display: block;
     width: 32px;
     height: 32px;

--- a/css/dns.css
+++ b/css/dns.css
@@ -2050,7 +2050,7 @@ html[data-theme='dark'] .mobile-menu #moonLottieBlack {
     width: 32px;
     height: 32px;
     mask: url("/assets/refresh.svg") no-repeat center / contain;
-    background-color: red;
+    background-color: var(--accent-default);
 }
 /* FLIP */
 

--- a/css/dns.css
+++ b/css/dns.css
@@ -2049,7 +2049,8 @@ html[data-theme='dark'] .mobile-menu #moonLottieBlack {
     display: block;
     width: 32px;
     height: 32px;
-    mask: url("/assets/refresh.svg") no-repeat center / contain;
+    mask: url("/assets/refresh.svg");
+    -webkit-mask: url("/assets/refresh.svg");
     background-color: var(--accent-default);
 }
 /* FLIP */

--- a/css/dns.css
+++ b/css/dns.css
@@ -2045,6 +2045,14 @@ html[data-theme='dark'] .mobile-menu #moonLottieBlack {
     padding: 0;
 }
 
+.failedTimerIconContainer:hover{
+    background: unset;
+}
+
+.failedTimerIconContainer:hover .failedTimerIcon{
+    background-color: var(--accent-hover);
+}
+
 .failedTimerIcon{
     display: block;
     width: 32px;

--- a/css/dns.css
+++ b/css/dns.css
@@ -2068,6 +2068,16 @@ html[data-theme='dark'] .mobile-menu #moonLottieBlack {
     line-height: 28px;
 }
 
+.flipTimerContainer--loading{
+    border-radius: 24px;
+    margin-top: 24px;
+    background: var(--loader--background--gradient);
+    animation: var(--gradient--animation--transition);
+}
+.flipTimerContainer--loading *{
+    opacity: 0;
+}
+
 @media screen and (max-width: 568px) {
     .expires__date {
         font-size: 16px;

--- a/css/dns.css
+++ b/css/dns.css
@@ -2038,16 +2038,36 @@ html[data-theme='dark'] .mobile-menu #moonLottieBlack {
 .in {
     opacity: 1;
 }
+.failedTimerIconContainer{
+    background: unset;
+    width: max-content;
+    margin: 0 auto;
+    padding: 0;
+}
 
+.failedTimerIcon{
+    display: block;
+    width: 32px;
+    height: 32px;
+    mask: url("/assets/refresh.svg") no-repeat center / contain;
+    background-color: red;
+}
 /* FLIP */
 
 .flip__container {
+    width: 448px;
     padding-top: 24px;
     display: flex;
     gap: 12px;
     flex-direction: column;
     justify-content: center;
     align-items: center;
+}
+
+@media screen and (max-width: 568px) {
+    .flip__container {
+        width: 343px;
+    }
 }
 
 .flip__row {
@@ -2066,16 +2086,6 @@ html[data-theme='dark'] .mobile-menu #moonLottieBlack {
     font-weight: 400;
     font-size: 18px;
     line-height: 28px;
-}
-
-.flipTimerContainer--loading{
-    border-radius: 24px;
-    margin-top: 24px;
-    background: var(--loader--background--gradient);
-    animation: var(--gradient--animation--transition);
-}
-.flipTimerContainer--loading *{
-    opacity: 0;
 }
 
 @media screen and (max-width: 568px) {

--- a/css/flip-clock.css
+++ b/css/flip-clock.css
@@ -150,15 +150,15 @@
     animation: currentDownShadowAnim 0.9s linear forwards;
 }
 
-.flipTimerContainer--loading .flip-clock-container [class|="flip-item"] .flip-digit{
+.flip-timer-container--loading .flip-clock-container [class|="flip-item"] .flip-digit{
     background: var(--loader--background--gradient);
     animation: 3s linear infinite alternate shine-lines-timer-item;
 }
-.flipTimerContainer--loading .flip-clock-container .flip-item-days .flip-digit{
+.flip-timer-container--loading .flip-clock-container .flip-item-days .flip-digit{
     animation: 3s linear infinite alternate shine-lines-timer-days;
 }
 
-.flipTimerContainer--loading .flip-clock-container [class|="flip-item"] .flip-digit *{
+.flip-timer-container--loading .flip-clock-container [class|="flip-item"] .flip-digit *{
     opacity: 0;
 }
 

--- a/css/flip-clock.css
+++ b/css/flip-clock.css
@@ -150,6 +150,18 @@
     animation: currentDownShadowAnim 0.9s linear forwards;
 }
 
+.flipTimerContainer--loading .flip-clock-container [class|="flip-item"] .flip-digit{
+    background: var(--loader--background--gradient);
+    animation: 3s linear infinite alternate shine-lines-timer-item;
+}
+.flipTimerContainer--loading .flip-clock-container .flip-item-days .flip-digit{
+    animation: 3s linear infinite alternate shine-lines-timer-days;
+}
+
+.flipTimerContainer--loading .flip-clock-container [class|="flip-item"] .flip-digit *{
+    opacity: 0;
+}
+
 @media screen and (max-width: 568px) {
     .flip-clock-container {
         width: 343px;

--- a/index.html
+++ b/index.html
@@ -174,12 +174,26 @@
             </p>
         </div>
 
-        <div class="flip__container">
+        <div class="flip__container" id="auction-flip-timer-container">
             <span class="expires__date" data-locale="auction_ends">Auction ends in</span>
             <div id="auctionEndsRow" class="flip__row">
                 <div id="actionEndDate" class="flip__strong">
                     <ul class="flip-clock-container" id="auction-bid-flip-clock-container" data-end-date="December 12, 2022 00:00:00"></ul>
                 </div>
+            </div>
+        </div>
+
+        <div id="auction-failed-timer-block">
+
+            <span class="buttonWrapper expires__date" data-locale="failed_timer">
+                Не получилось определить длительность аукциона
+            </span>
+            <div class="buttonWrapper">
+            <a class="btn" onclick="refreshPage()">
+                <span data-locale="refresh_page">
+                    Refresh page
+                </span>
+            </a>
             </div>
         </div>
 
@@ -251,7 +265,7 @@
             </div>
         </div>
 
-        <div class="flip__container">
+        <div class="flip__container" id="busy-flip-timer-container">
             <span class="expires__date" data-locale="expires">
                 Expires on
                 <span id="expiresDate"></span>
@@ -261,6 +275,21 @@
                     <ul class="flip-clock-container" id="flip-clock-container" data-end-date="December 12, 2022 00:00:00"></ul>
                 </div>
             </div>
+        </div>
+
+        <div id="busy-failed-timer-block">
+            <p class="buttonWrapper">
+                <span class="expires__date" data-locale="failed_timer">
+                    Не получилось определить длительность аукциона
+                </span>
+            </p>
+            <p class="buttonWrapper">
+                <a class="btn" onclick="refreshPage()">
+                    <span data-locale="refresh_page">
+                        Refresh page
+                    </span>
+                </a>
+            </p>
         </div>
 
         <p class="buttonWrapper">

--- a/index.html
+++ b/index.html
@@ -174,26 +174,12 @@
             </p>
         </div>
 
-        <div class="flip__container" id="auction-flip-timer-container">
+        <div class="flip__container flipTimerContainer" id="auction-flip-timer-container">
             <span class="expires__date" data-locale="auction_ends">Auction ends in</span>
             <div id="auctionEndsRow" class="flip__row">
                 <div id="actionEndDate" class="flip__strong">
                     <ul class="flip-clock-container" id="auction-bid-flip-clock-container" data-end-date="December 12, 2022 00:00:00"></ul>
                 </div>
-            </div>
-        </div>
-
-        <div id="auction-failed-timer-block">
-
-            <span class="buttonWrapper expires__date" data-locale="failed_timer">
-                Could not determine the duration of the auction
-            </span>
-            <div class="buttonWrapper">
-            <a class="btn" onclick="refreshPage()">
-                <span data-locale="refresh_page">
-                    Refresh page
-                </span>
-            </a>
             </div>
         </div>
 
@@ -265,7 +251,7 @@
             </div>
         </div>
 
-        <div class="flip__container" id="busy-flip-timer-container">
+        <div class="flip__container flipTimerContainer" id="busy-flip-timer-container">
             <span class="expires__date" data-locale="expires">
                 Expires on
                 <span id="expiresDate"></span>
@@ -275,21 +261,6 @@
                     <ul class="flip-clock-container" id="flip-clock-container" data-end-date="December 12, 2022 00:00:00"></ul>
                 </div>
             </div>
-        </div>
-
-        <div id="busy-failed-timer-block">
-            <p class="buttonWrapper">
-                <span class="expires__date" data-locale="failed_timer">
-                    Could not determine the duration of the auction
-                </span>
-            </p>
-            <p class="buttonWrapper">
-                <a class="btn" onclick="refreshPage()">
-                    <span data-locale="refresh_page">
-                        Refresh page
-                    </span>
-                </a>
-            </p>
         </div>
 
         <p class="buttonWrapper">

--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
             <span class="expires__date" data-locale="failed_timer">
                 Auction duration
             </span>
-            <a class="btn failedTimerIconContainer" onclick="refetchAuctionDomainTimerInfo()">
+            <a class="btn failedTimerIconContainer" onclick="reFetchAuctionDomainTimerInfo()">
                 <span class="failedTimerIcon"/>
             </a>
         </div>
@@ -276,7 +276,7 @@
             <span class="expires__date" data-locale="failed_timer">
                 Auction duration
             </span>
-            <a class="btn failedTimerIconContainer" onclick="refetchBusyDomainTimerInfo()">
+            <a class="btn failedTimerIconContainer" onclick="reFetchBusyDomainTimerInfo()">
                 <span class="failedTimerIcon"/>
             </a>
         </div>

--- a/index.html
+++ b/index.html
@@ -183,6 +183,15 @@
             </div>
         </div>
 
+        <div class="flip__container" id="auction-failed-timer-block">
+            <span class="expires__date" data-locale="failed_timer">
+                Auction duration
+            </span>
+            <a class="btn failedTimerIconContainer" onclick="refetchAuctionDomainTimerInfo()">
+                <span class="failedTimerIcon"/>
+            </a>
+        </div>
+
         <p class="buttonWrapper">
             <a id="auctionBtn" target="_blank" class="btn">
                 <img src="/assets/hammer.svg" alt="Place bid">
@@ -252,7 +261,7 @@
         </div>
 
         <div class="flip__container flipTimerContainer" id="busy-flip-timer-container">
-            <span class="expires__date" data-locale="expires">
+            <span class="expires__date" data-locale="expires" id="expiresDateContainer">
                 Expires on
                 <span id="expiresDate"></span>
             </span>
@@ -261,6 +270,15 @@
                     <ul class="flip-clock-container" id="flip-clock-container" data-end-date="December 12, 2022 00:00:00"></ul>
                 </div>
             </div>
+        </div>
+
+        <div class="flip__container" id="busy-failed-timer-block">
+            <span class="expires__date" data-locale="failed_timer">
+                Auction duration
+            </span>
+            <a class="btn failedTimerIconContainer" onclick="refetchBusyDomainTimerInfo()">
+                <span class="failedTimerIcon"/>
+            </a>
         </div>
 
         <p class="buttonWrapper">

--- a/index.html
+++ b/index.html
@@ -174,7 +174,10 @@
             </p>
         </div>
 
-        <div class="flip__container flipTimerContainer" id="auction-flip-timer-container">
+        <div
+                class="flip__container flipTimerContainer"
+                id="auction-flip-timer-container"
+        >
             <span class="expires__date" data-locale="auction_ends">Auction ends in</span>
             <div id="auctionEndsRow" class="flip__row">
                 <div id="actionEndDate" class="flip__strong">
@@ -187,7 +190,10 @@
             <span class="expires__date" data-locale="failed_timer">
                 Auction duration
             </span>
-            <a class="btn failedTimerIconContainer" onclick="reFetchAuctionDomainTimerInfo()">
+            <a
+                    class="btn failedTimerIconContainer"
+                    onclick="reFetchAuctionDomainTimerInfo()"
+            >
                 <span class="failedTimerIcon"/>
             </a>
         </div>
@@ -261,7 +267,11 @@
         </div>
 
         <div class="flip__container flipTimerContainer" id="busy-flip-timer-container">
-            <span class="expires__date" data-locale="expires" id="expiresDateContainer">
+            <span
+                    class="expires__date"
+                    data-locale="expires"
+                    id="expires-date-container"
+            >
                 Expires on
                 <span id="expiresDate"></span>
             </span>
@@ -276,7 +286,10 @@
             <span class="expires__date" data-locale="failed_timer">
                 Auction duration
             </span>
-            <a class="btn failedTimerIconContainer" onclick="reFetchBusyDomainTimerInfo()">
+            <a
+                    class="btn failedTimerIconContainer"
+                    onclick="reFetchBusyDomainTimerInfo()"
+            >
                 <span class="failedTimerIcon"/>
             </a>
         </div>

--- a/index.html
+++ b/index.html
@@ -191,8 +191,8 @@
                 Auction duration
             </span>
             <a
-                    class="btn failed-timer-icon-container"
-                    onclick="reFetchAuctionDomainTimerInfo()"
+                class="btn failed-timer-icon-container"
+                onclick="reFetchAuctionDomainTimerInfo()"
             >
                 <span class="failed-timer-icon"/>
             </a>
@@ -268,9 +268,9 @@
 
         <div class="flip__container flip-timer-container" id="busy-flip-timer-container">
             <span
-                    class="expires__date"
-                    data-locale="expires"
-                    id="expires-date-container"
+                class="expires__date"
+                data-locale="expires"
+                id="expires-date-container"
             >
                 Expires on
                 <span id="expiresDate"></span>
@@ -287,8 +287,8 @@
                 Auction duration
             </span>
             <a
-                    class="btn failed-timer-icon-container"
-                    onclick="reFetchBusyDomainTimerInfo()"
+                class="btn failed-timer-icon-container"
+                onclick="reFetchBusyDomainTimerInfo()"
             >
                 <span class="failed-timer-icon"/>
             </a>

--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
         <div id="auction-failed-timer-block">
 
             <span class="buttonWrapper expires__date" data-locale="failed_timer">
-                Не получилось определить длительность аукциона
+                Could not determine the duration of the auction
             </span>
             <div class="buttonWrapper">
             <a class="btn" onclick="refreshPage()">
@@ -280,7 +280,7 @@
         <div id="busy-failed-timer-block">
             <p class="buttonWrapper">
                 <span class="expires__date" data-locale="failed_timer">
-                    Не получилось определить длительность аукциона
+                    Could not determine the duration of the auction
                 </span>
             </p>
             <p class="buttonWrapper">

--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
         </div>
 
         <div
-                class="flip__container flipTimerContainer"
+                class="flip__container flip-timer-container"
                 id="auction-flip-timer-container"
         >
             <span class="expires__date" data-locale="auction_ends">Auction ends in</span>
@@ -191,10 +191,10 @@
                 Auction duration
             </span>
             <a
-                    class="btn failedTimerIconContainer"
+                    class="btn failed-timer-icon-container"
                     onclick="reFetchAuctionDomainTimerInfo()"
             >
-                <span class="failedTimerIcon"/>
+                <span class="failed-timer-icon"/>
             </a>
         </div>
 
@@ -266,7 +266,7 @@
             </div>
         </div>
 
-        <div class="flip__container flipTimerContainer" id="busy-flip-timer-container">
+        <div class="flip__container flip-timer-container" id="busy-flip-timer-container">
             <span
                     class="expires__date"
                     data-locale="expires"
@@ -287,10 +287,10 @@
                 Auction duration
             </span>
             <a
-                    class="btn failedTimerIconContainer"
+                    class="btn failed-timer-icon-container"
                     onclick="reFetchBusyDomainTimerInfo()"
             >
-                <span class="failedTimerIcon"/>
+                <span class="failed-timer-icon"/>
             </a>
         </div>
 

--- a/src/index.js
+++ b/src/index.js
@@ -304,9 +304,11 @@ const setDomain = (domain) => {
         const accountInfo = await tonweb.provider.getAddressInfo(
             domainAddressString
         )
+
         let dnsItem
         let domainExists = accountInfo.state === 'active'
         let ownerAddress = null
+
         if (domainExists) {
             dnsItem = new TonWeb.dns.DnsItem(tonweb.provider, {
                 address: domainAddress,
@@ -318,8 +320,10 @@ const setDomain = (domain) => {
                 ownerAddress = data.ownerAddress
             }
         }
+
         let isTimerLoadFail = false
         let auctionInfo = null
+
         if (domainExists && !ownerAddress) {
             auctionInfo = await dnsItem.methods.getAuctionInfo()
             if(!accountInfo){

--- a/src/index.js
+++ b/src/index.js
@@ -233,8 +233,7 @@ async function getDomainInfo(domain){
     const accountInfo = await tonweb.provider.getAddressInfo(
         domainAddressString
     )
-
-
+    
     let domainExists = accountInfo.state === 'active'
     let dnsItem = null
     let ownerAddress = null
@@ -530,7 +529,6 @@ function renderAuctionDomainTimer(auctionEndTime){
     // const isTimerLoadFail = !auctionEndTime || auctionEndTime < Date.now() / 1000
     const isTimerLoadFail = counterOfAuctionDomainTimerLoadError < 2 ? true : false
 
-
     if(isTimerLoadFail){
         counterOfAuctionDomainTimerLoadError += 1
 
@@ -576,7 +574,6 @@ const renderAuctionDomain = (domain, domainItemAddress, auctionInfo) => {
 
         previousBid = auctionAmount
 
-
         $('#auctionAmount').innerText = formatNumber(auctionAmount, false)
         $('#auctionAmountConverted').innerText = formatNumber(auctionAmount * price, 2)
         setAddress($('#auctionOwnerAddress'), bestBidAddress)
@@ -620,7 +617,6 @@ const renderFreeDomain = (domain) => {
     })
 }
 
-
 async function reFetchBusyDomainTimerInfo(){
     setTimerLoadingScreen(BUSY_FLIP_TIMER_CONTAINER_ID)
     toggle(`#${BUSY_FLIP_TIMER_CONTAINER_ID}`, true, 'flex')
@@ -631,7 +627,7 @@ async function reFetchBusyDomainTimerInfo(){
         ownerAddress,
         dnsItem
     } = await getDomainInfo(currentDomain)
-    
+
     let lastFillUpTime = 0
 
     if (domainExists && ownerAddress) {
@@ -1018,12 +1014,10 @@ const connectExtension = async (domain, dnsItem) => {
         return
     }
 
-
     if (!window.tonProtocolVersion || window.tonProtocolVersion < 1) {
         alert(locale.update_extension)
         return
     }
-
 
     const accounts = await provider.send('ton_requestAccounts')
     const account = new TonWeb.Address(accounts[0]).toString(
@@ -1117,7 +1111,6 @@ const connectExtension = async (domain, dnsItem) => {
             )
 
             $('#editAdnlRow input').placeholder = locale.adnl
-
 
             createEditBtn('#editAdnlRow .edit__button').addEventListener('click', () => {
                 const value = $('#editAdnlRow input').value // hex

--- a/src/index.js
+++ b/src/index.js
@@ -187,7 +187,7 @@ $('.badge__dns-mobile').addEventListener('click', () => {
     setScreen('startScreen')
 })
 
-const FLIP_TIMER_CONTAINER_LOADING_CLASSNAME = 'flipTimerContainer--loading'
+const FLIP_TIMER_CONTAINER_LOADING_CLASSNAME = 'flip-timer-container--loading'
 const AUCTION_BID_FLIP_CLOCK_CONTAINER_ID = 'auction-bid-flip-clock-container'
 const AUCTION_FLIP_TIMER_CONTAINER_ID = 'auction-flip-timer-container'
 const AUCTION_FAILED_TIMER_BLOCK_ID = 'auction-failed-timer-block'
@@ -255,7 +255,7 @@ async function getDomainInfo(domain){
 
     if (domainExists && !ownerAddress) {
         auctionInfo = await dnsItem.methods.getAuctionInfo()
-        if(!accountInfo){
+        if (!accountInfo){
             auctionInfo = await dnsItem.methods.getAuctionInfo()
         }
 
@@ -266,7 +266,7 @@ async function getDomainInfo(domain){
 
     if (domainExists && ownerAddress) {
         lastFillUpTime = await dnsItem.methods.getLastFillUpTime()
-        if(!lastFillUpTime){
+        if (!lastFillUpTime){
             lastFillUpTime = await dnsItem.methods.getLastFillUpTime()
         }
     }
@@ -482,14 +482,14 @@ function renderDomainLoadingScreen() {
 
 function setTimerLoadingScreen(id){
     const container = $(`#${id}`)
-    if(!container){
+    if (!container){
         return
     }
     container.classList.add(FLIP_TIMER_CONTAINER_LOADING_CLASSNAME)
 }
 function removeTimerLoadingScreen(id){
     const container = $(`#${id}`)
-    if(!container){
+    if (!container){
         return;
     }
     container.classList.remove(FLIP_TIMER_CONTAINER_LOADING_CLASSNAME)
@@ -525,13 +525,12 @@ async function reFetchAuctionDomainTimerInfo(){
 }
 
 function renderAuctionDomainTimer(auctionEndTime){
-    // const isTimerLoadFail = !auctionEndTime || auctionEndTime < Date.now() / 1000
-    const isTimerLoadFail = counterOfAuctionDomainTimerLoadError < 2 ? true : false
+    const isTimerLoadFail = !auctionEndTime || auctionEndTime < Date.now() / 1000
 
-    if(isTimerLoadFail){
+    if (isTimerLoadFail){
         counterOfAuctionDomainTimerLoadError += 1
 
-        if(counterOfAuctionDomainTimerLoadError < MAX_COUNT_OF_TIMER_ERROR_BEFORE_SHOW_BTN){
+        if (counterOfAuctionDomainTimerLoadError < MAX_COUNT_OF_TIMER_ERROR_BEFORE_SHOW_BTN){
             setTimerLoadingScreen(AUCTION_FLIP_TIMER_CONTAINER_ID)
             toggle(`#${AUCTION_FAILED_TIMER_BLOCK_ID}`, false, 'flex')
         } else {
@@ -636,14 +635,13 @@ async function reFetchBusyDomainTimerInfo(){
     renderBusyDomainTimer(lastFillUpTime)
 }
 function renderBusyDomainTimer(lastFillUpTime){
-    // const isTimerLoadFail = !lastFillUpTime
-    const isTimerLoadFail = counterOfBusyDomainTimerLoadError < 2 ? true : false
+    const isTimerLoadFail = !lastFillUpTime
 
-    if(isTimerLoadFail){
+    if (isTimerLoadFail){
         counterOfBusyDomainTimerLoadError += 1
         toggle(`#${EXPIRES_DATE_CONTAINER_ID}`, false, 'block')
 
-        if(counterOfBusyDomainTimerLoadError < MAX_COUNT_OF_TIMER_ERROR_BEFORE_SHOW_BTN){
+        if (counterOfBusyDomainTimerLoadError < MAX_COUNT_OF_TIMER_ERROR_BEFORE_SHOW_BTN){
             setTimerLoadingScreen(BUSY_FLIP_TIMER_CONTAINER_ID)
             toggle(`#${BUSY_FAILED_TIMER_BLOCK_ID}`, false, 'flex')
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -233,7 +233,7 @@ async function getDomainInfo(domain){
     const accountInfo = await tonweb.provider.getAddressInfo(
         domainAddressString
     )
-    
+
     let domainExists = accountInfo.state === 'active'
     let dnsItem = null
     let ownerAddress = null
@@ -657,7 +657,12 @@ function renderBusyDomainTimer(lastFillUpTime){
         counterOfBusyDomainTimerLoadError = 0
         const expiresDate = new Date(lastFillUpTime * 1000 + MS_IN_ONE_LEAP_YEAR)
 
-        $('#expiresDate').innerText = expiresDate.toISOString().slice(0,10).split('-').reverse().join(".")
+        $('#expiresDate').innerText = expiresDate
+            .toISOString()
+            .slice(0,10)
+            .split('-')
+            .reverse()
+            .join(".")
         $('#flip-clock-container').dataset.endDate = expiresDate
 
         toggle(`#${EXPIRES_DATE_CONTAINER_ID}`, true, 'block')

--- a/src/index.js
+++ b/src/index.js
@@ -487,6 +487,7 @@ function setTimerLoadingScreen(id){
     }
     container.classList.add(FLIP_TIMER_CONTAINER_LOADING_CLASSNAME)
 }
+
 function removeTimerLoadingScreen(id){
     const container = $(`#${id}`)
     if (!container){
@@ -634,6 +635,7 @@ async function reFetchBusyDomainTimerInfo(){
 
     renderBusyDomainTimer(lastFillUpTime)
 }
+
 function renderBusyDomainTimer(lastFillUpTime){
     const isTimerLoadFail = !lastFillUpTime
 
@@ -675,7 +677,7 @@ const renderBusyDomain = (
     domain,
     domainItemAddress,
     ownerAddress,
-    lastFillUpTime,
+    lastFillUpTime
 ) => {
     setAddress($('#busyOwnerAddress'), ownerAddress)
     renderBusyDomainTimer(lastFillUpTime)

--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,7 @@ const localeDict = {
         invalid_address: 'The address is invalid.',
         install_extension: 'Please install the TON Wallet extension to edit the domain',
         auction: 'On auction',
+        failed_timer: 'Could not determine the duration of the auction',
         free: 'Available',
         busy: 'Taken',
         update_extension: 'Please update your TON Wallet extension',

--- a/src/index.js
+++ b/src/index.js
@@ -291,12 +291,12 @@ const setDomain = (domain) => {
                     domainAddressString,
                     ownerAddress.toString(true, true, true, IS_TESTNET),
                     lastFillUpTime,
-                    isTimerLoadFail
+                    true
                 )
                 setScreen('busyDomainScreen')
             } else {
                 storeDomainStatus('auction')
-                renderAuctionDomain(domain, domainAddressString, auctionInfo, isTimerLoadFail)
+                renderAuctionDomain(domain, domainAddressString, auctionInfo, true)
                 setScreen('auctionDomainScreen')
             }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,6 @@ const localeDict = {
         invalid_address: 'The address is invalid.',
         install_extension: 'Please install the TON Wallet extension to edit the domain',
         auction: 'On auction',
-        failed_timer: 'Could not determine the duration of the auction',
         free: 'Available',
         busy: 'Taken',
         update_extension: 'Please update your TON Wallet extension',
@@ -419,6 +418,21 @@ function renderDomainLoadingScreen() {
     $('.main').classList.toggle('main--loading')
 }
 
+function setTimerLoadingScreen(id){
+    const container = $(`#${id}`)
+    if(!container){
+        return
+    }
+    container.classList.add('flipTimerContainer--loading')
+}
+function removeTimerLoadingScreen(id){
+    const container = $(`#${id}`)
+    if(!container){
+        return;
+    }
+    container.classList.remove('flipTimerContainer--loading')
+}
+
 let timeoutId = null;
 
 function renderStatusLoading() {
@@ -446,11 +460,9 @@ const renderAuctionDomain = (domain, domainItemAddress, auctionInfo, isTimerLoad
         IS_TESTNET
     )
     if(isTimerLoadFail){
-        toggle('#auction-failed-timer-block', true, 'block')
-        toggle('#auction-flip-timer-container', false, 'flex')
+        setTimerLoadingScreen('auction-flip-timer-container')
     }else{
-        toggle('#auction-failed-timer-block', false, 'block')
-        toggle('#auction-flip-timer-container', true, 'flex')
+        removeTimerLoadingScreen('auction-flip-timer-container')
         $('#auction-bid-flip-clock-container').dataset.endDate = new Date(auctionEndTime * 1000)
         initFlipTimer('#auction-bid-flip-clock-container', true)
     }
@@ -519,13 +531,10 @@ const renderBusyDomain = (
     isTimerLoadFail
 ) => {
     setAddress($('#busyOwnerAddress'), ownerAddress)
-
     if(isTimerLoadFail){
-        toggle('#busy-flip-timer-container', false, 'flex')
-        toggle('#busy-failed-timer-block', true, 'block')
+        setTimerLoadingScreen('busy-flip-timer-container')
     }else{
-        toggle('#busy-flip-timer-container', true, 'flex')
-        toggle('#busy-failed-timer-block', false, 'block')
+        removeTimerLoadingScreen('busy-flip-timer-container')
 
         const expiresDate = new Date(lastFillUpTime * 1000 + MS_IN_ONE_LEAP_YEAR)
 

--- a/src/index.js
+++ b/src/index.js
@@ -187,6 +187,7 @@ $('.badge__dns-mobile').addEventListener('click', () => {
     setScreen('startScreen')
 })
 
+const FLIP_TIMER_CONTAINER_LOADING_CLASSNAME = 'flipTimerContainer--loading'
 const AUCTION_BID_FLIP_CLOCK_CONTAINER_ID = 'auction-bid-flip-clock-container'
 const AUCTION_FLIP_TIMER_CONTAINER_ID = 'auction-flip-timer-container'
 const AUCTION_FAILED_TIMER_BLOCK_ID = 'auction-failed-timer-block'
@@ -478,8 +479,6 @@ window.onpopstate = () => processUrl()
 function renderDomainLoadingScreen() {
     $('.main').classList.toggle('main--loading')
 }
-
-const FLIP_TIMER_CONTAINER_LOADING_CLASSNAME = 'flipTimerContainer--loading'
 
 function setTimerLoadingScreen(id){
     const container = $(`#${id}`)

--- a/src/index.js
+++ b/src/index.js
@@ -272,7 +272,7 @@ const setDomain = (domain) => {
             }
             if(!lastFillUpTime){
                 isTimerLoadFail = true
-            }else{
+            } else{
                 isTimerLoadFail = false
             }
         }
@@ -451,6 +451,7 @@ function renderStatusLoading() {
 }
 
 const renderAuctionDomain = (domain, domainItemAddress, auctionInfo, isTimerLoadFail) => {
+
     const auctionEndTime = auctionInfo.auctionEndTime // unixtime
     const bestBidAmount = auctionInfo.maxBidAmount
     const bestBidAddress = auctionInfo.maxBidAddress.toString(
@@ -461,7 +462,7 @@ const renderAuctionDomain = (domain, domainItemAddress, auctionInfo, isTimerLoad
     )
     if(isTimerLoadFail){
         setTimerLoadingScreen('auction-flip-timer-container')
-    }else{
+    } else{
         removeTimerLoadingScreen('auction-flip-timer-container')
         $('#auction-bid-flip-clock-container').dataset.endDate = new Date(auctionEndTime * 1000)
         initFlipTimer('#auction-bid-flip-clock-container', true)
@@ -533,7 +534,7 @@ const renderBusyDomain = (
     setAddress($('#busyOwnerAddress'), ownerAddress)
     if(isTimerLoadFail){
         setTimerLoadingScreen('busy-flip-timer-container')
-    }else{
+    } else{
         removeTimerLoadingScreen('busy-flip-timer-container')
 
         const expiresDate = new Date(lastFillUpTime * 1000 + MS_IN_ONE_LEAP_YEAR)


### PR DESCRIPTION
Solution:
1. Check if the data for the timer has loaded
2.1 If loaded - displays
2.2 If not loaded, add a shimmer to the blocks inside the timer and make a second request
3.1 If loaded - remove the shimmer
3.2 If not loaded - hide the timer and show the timer refresh button
4. When you click on this button, the information for the timer is fetched separately from the fetch of information for the domain - that is, without refreshing the page.
5. If the correct information on the timer has arrived, then reset the error counter on it, remove the block with the button and display the timer