### PR TITLE
fix: hide page while locale loading

### DIFF
--- a/about.html
+++ b/about.html
@@ -48,7 +48,7 @@
         initTheme();
     </script>
 </head>
-<body class="about--body">
+<body class="about--body hidden">
 <nav class="absolute-header">
     <div class="container-inner">
         <div class="badge">

--- a/css/dns.css
+++ b/css/dns.css
@@ -18,6 +18,7 @@ body {
     background-color: var(--background-page);
     color: var(--text-secondary);
     position: relative;
+    transition: 0.1s opacity;
 }
 
 * {
@@ -34,6 +35,10 @@ body.scroll__disabled {
     top: 0;
     bottom: 0;
     right: 0;
+}
+
+body.hidden{
+    opacity: 0;
 }
 
 .btn {

--- a/css/dns.css
+++ b/css/dns.css
@@ -18,7 +18,6 @@ body {
     background-color: var(--background-page);
     color: var(--text-secondary);
     position: relative;
-    transition: 0.1s opacity;
 }
 
 * {

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         initTheme();
     </script>
 </head>
-<body>
+<body class="hidden">
 <nav>
     <div class="testnet-badge">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20" class="icon testnet__icon">

--- a/src/about.js
+++ b/src/about.js
@@ -79,7 +79,7 @@ if (lang !== 'en') {
     })
 }
 
-togglePageVisible()
+makePageVisible()
 
 ;(function () {
     window.onload = function () {

--- a/src/about.js
+++ b/src/about.js
@@ -79,6 +79,8 @@ if (lang !== 'en') {
     })
 }
 
+togglePageVisible()
+
 ;(function () {
     window.onload = function () {
         toggle('#about', true, 'flex')

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ if (lang !== 'en') {
     })
 }
 
-togglePageVisible()
+makePageVisible()
 
 const IS_TESTNET = window.location.href.indexOf('testnet=true') > -1
 

--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,8 @@ if (lang !== 'en') {
     })
 }
 
+togglePageVisible()
+
 const IS_TESTNET = window.location.href.indexOf('testnet=true') > -1
 
 const AUCTION_START_TIME = IS_TESTNET ? 1659125865 : 1659171600

--- a/src/utils.js
+++ b/src/utils.js
@@ -343,3 +343,7 @@ window.BROWSER = (function (agent) {
         default: return "other";
     }
 })(window.navigator.userAgent.toLowerCase());
+
+function togglePageVisible(){
+    document.body.classList.toggle('hidden')
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -344,6 +344,6 @@ window.BROWSER = (function (agent) {
     }
 })(window.navigator.userAgent.toLowerCase());
 
-function togglePageVisible(){
-    document.body.classList.toggle('hidden')
+function makePageVisible(){
+    document.body.classList.remove('hidden')
 }


### PR DESCRIPTION
Bug - tongue blinking on page load
Solution - add opacity to the page until all translations are loaded