### PR TITLE
fix: placeholder “.ton” is added to the “.ton” we specified at the end

### DIFF
--- a/css/dns.css
+++ b/css/dns.css
@@ -456,6 +456,7 @@ body.scroll__disabled {
     font-size: 18px;
     bottom: 50%;
     transform: translateY(50%);
+    line-height: 28px;
 }
 
 .icon.reset__input--icon {
@@ -505,6 +506,9 @@ body.scroll__disabled {
     .start-input {
         padding: 16px 56px;
         font-size: 16px;
+        line-height: 24px;
+    }
+    .start-input-container__domain{
         line-height: 24px;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1014,6 +1014,7 @@ $(".reset__input--icon").addEventListener('click', (e) => {
 
 // COMMON
 var oldStartInputValue = '';
+const DEFAULT_CARETE_HELPER_TEXT = '.ton'
 
 function setCareeteHelperValue(value) {
     const helper = $('.careete__helper');
@@ -1022,7 +1023,21 @@ function setCareeteHelperValue(value) {
     const resetInputIcon = $('.icon.reset__input--icon')
     const careeteHelper = $('.start-input-container__domain--container')
     const careeteHelperText = $('.start-input-container__domain')
-    const isValueContainDotTon = value?.length ? value.slice(value.length - 4) === '.ton' : false
+
+    function getSubStrAfterSubStr(str, substring) {
+        let lastIndex = str.lastIndexOf(substring);
+        if (lastIndex === -1) {
+            return 0;
+        }
+
+        return str.slice(lastIndex)
+    }
+
+    const cuttedHintText = getSubStrAfterSubStr(value, '.')
+
+    $('.start-input-container__domain').innerText = cuttedHintText && DEFAULT_CARETE_HELPER_TEXT.includes(cuttedHintText)
+        ? DEFAULT_CARETE_HELPER_TEXT.slice(cuttedHintText.length)
+        : DEFAULT_CARETE_HELPER_TEXT
 
     if (value !== oldStartInputValue) {
         oldStartInputValue = value;
@@ -1041,10 +1056,6 @@ function setCareeteHelperValue(value) {
                 careeteHelper.style.visibility = 'visible';
             }
         }
-    }
-
-    if(isValueContainDotTon){
-        careeteHelper.style.visibility = 'hidden';
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1015,6 +1015,7 @@ $(".reset__input--icon").addEventListener('click', (e) => {
 // COMMON
 var oldStartInputValue = '';
 const DEFAULT_CARETE_HELPER_TEXT = '.ton'
+const OFFSET_BETWEEN_TEXT_AND_CARRETE = 1
 
 function setCareeteHelperValue(value) {
     const helper = $('.careete__helper');
@@ -1045,7 +1046,7 @@ function setCareeteHelperValue(value) {
         const {width} = helper.getBoundingClientRect();
 
         if (careeteHelper) {
-            careeteHelper.style.left = `${(windowWidth > 568 ? 72 : 56) + width}px`
+            careeteHelper.style.left = `${(windowWidth > 568 ? 72 : 56) + width + OFFSET_BETWEEN_TEXT_AND_CARRETE}px`
 
             const iconDimensions = resetInputIcon.getBoundingClientRect();
             const careeteHelperDimensions = careeteHelperText.getBoundingClientRect();

--- a/src/index.js
+++ b/src/index.js
@@ -1022,6 +1022,7 @@ function setCareeteHelperValue(value) {
     const resetInputIcon = $('.icon.reset__input--icon')
     const careeteHelper = $('.start-input-container__domain--container')
     const careeteHelperText = $('.start-input-container__domain')
+    const isValueContainDotTon = value?.length ? value.slice(value.length - 4) === '.ton' : false
 
     if (value !== oldStartInputValue) {
         oldStartInputValue = value;
@@ -1040,6 +1041,10 @@ function setCareeteHelperValue(value) {
                 careeteHelper.style.visibility = 'visible';
             }
         }
+    }
+
+    if(isValueContainDotTon){
+        careeteHelper.style.visibility = 'hidden';
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1020,7 +1020,6 @@ const OFFSET_BETWEEN_TEXT_AND_CARRETE = 1
 function setCareeteHelperValue(value) {
     const helper = $('.careete__helper');
     const windowWidth = window.innerWidth;
-
     const resetInputIcon = $('.icon.reset__input--icon')
     const careeteHelper = $('.start-input-container__domain--container')
     const careeteHelperText = $('.start-input-container__domain')
@@ -1042,7 +1041,8 @@ function setCareeteHelperValue(value) {
 
     if (value !== oldStartInputValue) {
         oldStartInputValue = value;
-        helper.innerText = value;
+        helper.innerText = value.replaceAll(' ', `${'\u00A0'}`);
+
         const {width} = helper.getBoundingClientRect();
 
         if (careeteHelper) {

--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,10 @@ let currentDomain = null
 let currentOwner = null
 let currentDnsItem = null
 let previousBid = null
+
 const removeListeners = {}
+const DEFAULT_CARETE_HELPER_TEXT = '.ton'
+const OFFSET_BETWEEN_TEXT_AND_CARRETE = 1
 
 const clear = () => {
     clearInterval(updateIntervalId)
@@ -1014,8 +1017,6 @@ $(".reset__input--icon").addEventListener('click', (e) => {
 
 // COMMON
 var oldStartInputValue = '';
-const DEFAULT_CARETE_HELPER_TEXT = '.ton'
-const OFFSET_BETWEEN_TEXT_AND_CARRETE = 1
 
 function setCareeteHelperValue(value) {
     const helper = $('.careete__helper');

--- a/src/index.js
+++ b/src/index.js
@@ -1033,7 +1033,7 @@ function setCareeteHelperValue(value) {
         return str.slice(lastIndex)
     }
 
-    const cuttedHintText = getSubStrAfterSubStr(value, '.')
+    const cuttedHintText = getSubStrAfterSubStr(value, DEFAULT_CARETE_HELPER_TEXT[0])
 
     $('.start-input-container__domain').innerText = cuttedHintText && DEFAULT_CARETE_HELPER_TEXT.includes(cuttedHintText)
         ? DEFAULT_CARETE_HELPER_TEXT.slice(cuttedHintText.length)


### PR DESCRIPTION
Bug - Placeholder “.ton” is added to the “.ton” we specified at the end
Solution - Each character matching the last characters from the input field is removed from the .ton hint
