### PR TITLE
V maks/fix bug of timer

### DIFF
--- a/assets/refresh.svg
+++ b/assets/refresh.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.99902 16C3.99902 9.37258 9.37161 4 15.999 4C22.6264 4 27.999 9.37258 27.999 16C27.999 22.6274 22.6264 28 15.999 28C12.592 28 9.51669 26.5802 7.33236 24.3" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1.33396 14.6656L3.98729 17.9189L6.64062 14.6656" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/css/constants.css
+++ b/css/constants.css
@@ -168,3 +168,23 @@ html[data-theme='dark'] {
         background-position: 440px
     }
 }
+
+@keyframes shine-lines-timer-days {
+    0% {
+        background-position: -114px
+    }
+
+    100% {
+        background-position: 114px
+    }
+}
+
+@keyframes shine-lines-timer-item {
+    0% {
+        background-position: -38px
+    }
+
+    100% {
+        background-position: 38px
+    }
+}

--- a/css/dns.css
+++ b/css/dns.css
@@ -2038,16 +2038,45 @@ html[data-theme='dark'] .mobile-menu #moonLottieBlack {
 .in {
     opacity: 1;
 }
+.failed-timer-icon-container{
+    background: unset;
+    width: max-content;
+    margin: 0 auto;
+    padding: 0;
+}
 
+.failed-timer-icon-container:hover{
+    background: unset;
+}
+
+.failed-timer-icon-container:hover .failed-timer-icon{
+    background-color: var(--accent-hover);
+}
+
+.failed-timer-icon{
+    display: block;
+    width: 32px;
+    height: 32px;
+    mask: url("/assets/refresh.svg");
+    -webkit-mask: url("/assets/refresh.svg");
+    background-color: var(--accent-default);
+}
 /* FLIP */
 
 .flip__container {
+    width: 448px;
     padding-top: 24px;
     display: flex;
     gap: 12px;
     flex-direction: column;
     justify-content: center;
     align-items: center;
+}
+
+@media screen and (max-width: 568px) {
+    .flip__container {
+        width: 343px;
+    }
 }
 
 .flip__row {

--- a/css/flip-clock.css
+++ b/css/flip-clock.css
@@ -150,6 +150,18 @@
     animation: currentDownShadowAnim 0.9s linear forwards;
 }
 
+.flip-timer-container--loading .flip-clock-container [class|="flip-item"] .flip-digit{
+    background: var(--loader--background--gradient);
+    animation: 3s linear infinite alternate shine-lines-timer-item;
+}
+.flip-timer-container--loading .flip-clock-container .flip-item-days .flip-digit{
+    animation: 3s linear infinite alternate shine-lines-timer-days;
+}
+
+.flip-timer-container--loading .flip-clock-container [class|="flip-item"] .flip-digit *{
+    opacity: 0;
+}
+
 @media screen and (max-width: 568px) {
     .flip-clock-container {
         width: 343px;

--- a/index.html
+++ b/index.html
@@ -174,13 +174,28 @@
             </p>
         </div>
 
-        <div class="flip__container">
+        <div
+                class="flip__container flip-timer-container"
+                id="auction-flip-timer-container"
+        >
             <span class="expires__date" data-locale="auction_ends">Auction ends in</span>
             <div id="auctionEndsRow" class="flip__row">
                 <div id="actionEndDate" class="flip__strong">
                     <ul class="flip-clock-container" id="auction-bid-flip-clock-container" data-end-date="December 12, 2022 00:00:00"></ul>
                 </div>
             </div>
+        </div>
+
+        <div class="flip__container" id="auction-failed-timer-block">
+            <span class="expires__date" data-locale="failed_timer">
+                Auction duration
+            </span>
+            <a
+                class="btn failed-timer-icon-container"
+                onclick="reFetchAuctionDomainTimerInfo()"
+            >
+                <span class="failed-timer-icon"/>
+            </a>
         </div>
 
         <p class="buttonWrapper">
@@ -251,8 +266,12 @@
             </div>
         </div>
 
-        <div class="flip__container">
-            <span class="expires__date" data-locale="expires">
+        <div class="flip__container flip-timer-container" id="busy-flip-timer-container">
+            <span
+                class="expires__date"
+                data-locale="expires"
+                id="expires-date-container"
+            >
                 Expires on
                 <span id="expiresDate"></span>
             </span>
@@ -261,6 +280,18 @@
                     <ul class="flip-clock-container" id="flip-clock-container" data-end-date="December 12, 2022 00:00:00"></ul>
                 </div>
             </div>
+        </div>
+
+        <div class="flip__container" id="busy-failed-timer-block">
+            <span class="expires__date" data-locale="failed_timer">
+                Auction duration
+            </span>
+            <a
+                class="btn failed-timer-icon-container"
+                onclick="reFetchBusyDomainTimerInfo()"
+            >
+                <span class="failed-timer-icon"/>
+            </a>
         </div>
 
         <p class="buttonWrapper">

--- a/src/flip-clock.js
+++ b/src/flip-clock.js
@@ -106,9 +106,18 @@ renderTimer = function ($, start) {
         var flipElements = {}
         var timestamp = 0
         var itemCount = 0
+        const timerId = flipContainer[0]?.parentElement?.id || ''
+
         flipContainer.children().each(function () {
             var element = $(this)
             var number = parseInt(element.text())
+
+            if (isNaN(number)){
+                setTimerLoadingScreen(timerId)
+            } else{
+                removeTimerLoadingScreen(timerId)
+            }
+
             var getFlipItemChildObj = prepareFlipItemChild(element, number)
 
             if (element.hasClass('flip-item-seconds')) {

--- a/src/flip.js
+++ b/src/flip.js
@@ -22,14 +22,25 @@ const getEndDate = (container) => {
     return formattedDate
 }
 
+const NUMBER_CHARACTER_TO_COPY = 3
+
 const calculateExpiresTime = (endDate) => {
     const ONE_SECOND = 1000
     const ONE_MINUTE = ONE_SECOND * 60
     const ONE_HOUR = ONE_MINUTE * 60
     const ONE_DAY = 24 * 60 * 60 * 1000
 
-    const todayDate = new Date()
-    const dateDifference = Math.abs(todayDate - endDate)
+    const todayDateTimestamp = new Date().getTime()
+    const todayDateString = String(todayDateTimestamp)
+    const stringEndDateTimestamp = String(endDate.getTime())
+    const arrayEndDateTimestamp = stringEndDateTimestamp.split('')
+
+    for (let i = 1; i < NUMBER_CHARACTER_TO_COPY + 1; i++) {
+        arrayEndDateTimestamp[arrayEndDateTimestamp.length - i] = todayDateString[todayDateString.length - i]
+    }
+
+    const formattedEndDateTimestamp = Number(arrayEndDateTimestamp.join(''))
+    const dateDifference = Math.abs(todayDateTimestamp - formattedEndDateTimestamp)
 
     const daysLeft = Math.max(0, Math.floor(dateDifference / ONE_DAY))
     const hoursLeft = Math.max(0, Math.floor((dateDifference / ONE_HOUR) % 24))

--- a/src/flip.js
+++ b/src/flip.js
@@ -85,6 +85,7 @@ const initTimer = (selector, start) => {
 }
 
 const unmountTimer = () => {
+    isTimerMounted = false
     document.querySelectorAll('.flip-clock-container').forEach((container) => {
         container.innerHTML = ''
     })

--- a/src/index.js
+++ b/src/index.js
@@ -512,7 +512,9 @@ async function reFetchAuctionDomainTimerInfo(){
 }
 
 function renderAuctionDomainTimer(auctionEndTime){
-    const isTimerLoadFail = !auctionEndTime || auctionEndTime < Date.now() / 1000
+    // const isTimerLoadFail = !auctionEndTime || auctionEndTime < Date.now() / 1000
+    //TODO delete after presentation on demo stand
+    const isTimerLoadFail = counterOfAuctionDomainTimerLoadError > 2 ? false : true
 
     if (isTimerLoadFail){
         counterOfAuctionDomainTimerLoadError += 1
@@ -527,7 +529,8 @@ function renderAuctionDomainTimer(auctionEndTime){
         }
 
     } else {
-        counterOfAuctionDomainTimerLoadError = 0
+        //TODO delete comment after presentation on demo stand
+        // counterOfAuctionDomainTimerLoadError = 0
         const prevDate = $(`#${AUCTION_BID_FLIP_CLOCK_CONTAINER_ID}`).dataset.endDate
         const endDate = new Date(auctionEndTime * 1000)
         const isDateEqual = String(prevDate) === String(endDate)
@@ -643,7 +646,9 @@ async function reFetchBusyDomainTimerInfo(){
 }
 
 function renderBusyDomainTimer(lastFillUpTime){
-    const isTimerLoadFail = !lastFillUpTime
+    // const isTimerLoadFail = !lastFillUpTime
+    //TODO delete after presentation on demo stand
+    const isTimerLoadFail = counterOfBusyDomainTimerLoadError > 2 ? false : true
 
     if (isTimerLoadFail){
         counterOfBusyDomainTimerLoadError += 1
@@ -659,7 +664,8 @@ function renderBusyDomainTimer(lastFillUpTime){
         }
     }
     else {
-        counterOfBusyDomainTimerLoadError = 0
+        //TODO delete comment after presentation on demo stand
+        // counterOfBusyDomainTimerLoadError = 0
         const expiresDate = new Date(lastFillUpTime * 1000 + MS_IN_ONE_LEAP_YEAR)
         const prevDate = $(`#${BUSY_TIMER_BLOCK_ID}`).dataset.endDate
         const isDateEqual = String(prevDate) === String(expiresDate)

--- a/src/index.js
+++ b/src/index.js
@@ -426,8 +426,14 @@ const renderAuctionDomain = (domain, domainItemAddress, auctionInfo) => {
         IS_TESTNET
     )
 
-    $('#auction-bid-flip-clock-container').dataset.endDate = new Date(auctionEndTime * 1000)
-    initFlipTimer('#auction-bid-flip-clock-container', true)
+    const prevDate = $('#auction-bid-flip-clock-container').dataset.endDate
+    const endDate = new Date(auctionEndTime * 1000)
+    const isDateEqual = String(prevDate) === String(endDate)
+
+    if (!isDateEqual){
+        $('#auction-bid-flip-clock-container').dataset.endDate = endDate
+        initFlipTimer('#auction-bid-flip-clock-container', true)
+    }
 
     getCoinPrice().then((price) => {
         const auctionAmount = TonWeb.utils.fromNano(bestBidAmount)
@@ -495,10 +501,15 @@ const renderBusyDomain = (
 ) => {
     setAddress($('#busyOwnerAddress'), ownerAddress)
     const expiresDate = new Date(lastFillUpTime * 1000 + MS_IN_ONE_LEAP_YEAR)
+    const prevDate = $('#flip-clock-container').dataset.endDate
+    const isDateEqual = String(prevDate) === String(expiresDate)
 
     $('#expiresDate').innerText = expiresDate.toISOString().slice(0,10).split('-').reverse().join(".")
-    $('#flip-clock-container').dataset.endDate = expiresDate
-    initFlipTimer('#flip-clock-container', true)
+
+    if (!isDateEqual) {
+        $('#flip-clock-container').dataset.endDate = expiresDate
+        initFlipTimer('#flip-clock-container', true)
+    }
 }
 
 const renderSearchHistory = (node) => {

--- a/src/index.js
+++ b/src/index.js
@@ -484,9 +484,11 @@ const renderFreeDomain = (domain) => {
             $('#freeMinBetConverted').innerText = formatNumber(salePrice * price, 2)
         }
 
-        $('#bid-flip-clock-container').dataset.endDate = new Date(
-            Date.now() + getAuctionDuration() * 1000
-        ).toISOString()
+        const auctionDuration = getAuctionDuration()
+        const formattedDuration = Date.now() + auctionDuration * 1000
+        const formattedDurationDate = new Date(formattedDuration)
+        $('#bid-flip-clock-container').dataset.endDate = formattedDurationDate.toISOString()
+
         initFlipTimer('#bid-flip-clock-container', false)
 
         attachBidModalListeners(domain, salePrice, '#bidButton')

--- a/src/index.js
+++ b/src/index.js
@@ -193,7 +193,9 @@ const AUCTION_FLIP_TIMER_CONTAINER_ID = 'auction-flip-timer-container'
 const AUCTION_FAILED_TIMER_BLOCK_ID = 'auction-failed-timer-block'
 const BUSY_FLIP_TIMER_CONTAINER_ID = 'busy-flip-timer-container'
 const BUSY_FAILED_TIMER_BLOCK_ID = 'busy-failed-timer-block'
+const BUSY_TIMER_BLOCK_ID = 'flip-clock-container'
 const EXPIRES_DATE_CONTAINER_ID = 'expires-date-container'
+const FREE_TIMER_BLOCK_ID = 'bid-flip-clock-container'
 
 // SET DOMAIN
 
@@ -480,22 +482,6 @@ function renderDomainLoadingScreen() {
     $('.main').classList.toggle('main--loading')
 }
 
-function setTimerLoadingScreen(id){
-    const container = $(`#${id}`)
-    if (!container){
-        return
-    }
-    container.classList.add(FLIP_TIMER_CONTAINER_LOADING_CLASSNAME)
-}
-
-function removeTimerLoadingScreen(id){
-    const container = $(`#${id}`)
-    if (!container){
-        return;
-    }
-    container.classList.remove(FLIP_TIMER_CONTAINER_LOADING_CLASSNAME)
-}
-
 let timeoutId = null;
 
 function renderStatusLoading() {
@@ -542,20 +528,26 @@ function renderAuctionDomainTimer(auctionEndTime){
 
     } else {
         counterOfAuctionDomainTimerLoadError = 0
-        const prevDate = $('#auction-bid-flip-clock-container').dataset.endDate
+        const prevDate = $(`#${AUCTION_BID_FLIP_CLOCK_CONTAINER_ID}`).dataset.endDate
         const endDate = new Date(auctionEndTime * 1000)
         const isDateEqual = String(prevDate) === String(endDate)
-
-        if (!isDateEqual){
-            $('#auction-bid-flip-clock-container').dataset.endDate = endDate
-            initFlipTimer('#auction-bid-flip-clock-container', true)
-        }
 
         toggle(`#${AUCTION_FLIP_TIMER_CONTAINER_ID}`, true, 'flex')
         toggle(`#${AUCTION_FAILED_TIMER_BLOCK_ID}`, false, 'flex')
         removeTimerLoadingScreen(AUCTION_FLIP_TIMER_CONTAINER_ID)
+
+        if (!isDateEqual){
+            $(`#${AUCTION_BID_FLIP_CLOCK_CONTAINER_ID}`).dataset.endDate = endDate
+        }
+
+        if(!isDateEqual || !isTimerMounted){
+            initFlipTimer(`#${AUCTION_BID_FLIP_CLOCK_CONTAINER_ID}`, true)
+        }
     }
-    initFlipTimer(`#${AUCTION_BID_FLIP_CLOCK_CONTAINER_ID}`, true)
+
+    if(!isTimerMounted){
+        initFlipTimer(`#${AUCTION_BID_FLIP_CLOCK_CONTAINER_ID}`, false)
+    }
 }
 
 const renderAuctionDomain = (domain, domainItemAddress, auctionInfo) => {
@@ -622,9 +614,9 @@ const renderFreeDomain = (domain) => {
         const auctionDuration = getAuctionDuration()
         const formattedDuration = Date.now() + auctionDuration * 1000
         const formattedDurationDate = new Date(formattedDuration)
-        $('#bid-flip-clock-container').dataset.endDate = formattedDurationDate.toISOString()
+        $(`#${FREE_TIMER_BLOCK_ID}`).dataset.endDate = formattedDurationDate.toISOString()
 
-        initFlipTimer('#bid-flip-clock-container', false)
+        initFlipTimer(`#${FREE_TIMER_BLOCK_ID}`, false)
 
         attachBidModalListeners(domain, salePrice, '#bidButton')
     })
@@ -669,7 +661,7 @@ function renderBusyDomainTimer(lastFillUpTime){
     else {
         counterOfBusyDomainTimerLoadError = 0
         const expiresDate = new Date(lastFillUpTime * 1000 + MS_IN_ONE_LEAP_YEAR)
-        const prevDate = $('#flip-clock-container').dataset.endDate
+        const prevDate = $(`#${BUSY_TIMER_BLOCK_ID}`).dataset.endDate
         const isDateEqual = String(prevDate) === String(expiresDate)
 
         $('#expiresDate').innerText = expiresDate
@@ -679,18 +671,22 @@ function renderBusyDomainTimer(lastFillUpTime){
             .reverse()
             .join(".")
 
-        if (!isDateEqual) {
-            $('#flip-clock-container').dataset.endDate = expiresDate
-            initFlipTimer('#flip-clock-container', true)
-        }
-
         toggle(`#${EXPIRES_DATE_CONTAINER_ID}`, true, 'block')
         toggle(`#${BUSY_FLIP_TIMER_CONTAINER_ID}`, true, 'flex')
         toggle(`#${BUSY_FAILED_TIMER_BLOCK_ID}`, false, 'flex')
         removeTimerLoadingScreen(BUSY_FLIP_TIMER_CONTAINER_ID)
+
+        if (!isDateEqual) {
+            $(`#${BUSY_TIMER_BLOCK_ID}`).dataset.endDate = expiresDate
+        }
+        if(!isDateEqual || !isTimerMounted){
+            initFlipTimer(`#${BUSY_TIMER_BLOCK_ID}`, true)
+        }
     }
 
-    initFlipTimer('#flip-clock-container', false)
+    if(!isTimerMounted){
+        initFlipTimer(`#${BUSY_TIMER_BLOCK_ID}`, false)
+    }
 }
 
 const renderBusyDomain = (

--- a/src/utils.js
+++ b/src/utils.js
@@ -345,3 +345,19 @@ window.BROWSER = (function (agent) {
         default: return "other";
     }
 })(window.navigator.userAgent.toLowerCase());
+
+function setTimerLoadingScreen(id){
+    const container = $(`#${id}`)
+    if (!container){
+        return
+    }
+    container.classList.add(FLIP_TIMER_CONTAINER_LOADING_CLASSNAME)
+}
+
+function removeTimerLoadingScreen(id){
+    const container = $(`#${id}`)
+    if (!container){
+        return;
+    }
+    container.classList.remove(FLIP_TIMER_CONTAINER_LOADING_CLASSNAME)
+}


### PR DESCRIPTION
Bug - a unit of seconds can lag and switch without animation
Solution: Check if there is a change in the date from the server and if not, do not update the timer

Bug  - when loading data from the timer for auctions or busy domains, api may give an error and the timer will be displayed with NaN
Solution:
Check if the data for the timer has loaded
2.1 If loaded - displays
2.2 If not loaded, add a shimmer to the blocks inside the timer and make a second request
3.1 If loaded - remove the shimmer
3.2 If not loaded - hide the timer and show the timer refresh button
When you click on this button, the information for the timer is fetched separately from the fetch of information for the domain - that is, without refreshing the page.
If the correct information on the timer has arrived, then reset the error counter on it, remove the block with the button and display the timer