### PR TITLE
fix mobile modal bottom padding

### DIFF
--- a/css/dns.css
+++ b/css/dns.css
@@ -1771,6 +1771,7 @@ p {
         max-height: 660px;
         transform: none;
         padding: 24px 16px 16px 16px;
+        padding-bottom: max(env(safe-area-inset-bottom, 16px), 16px);
         box-sizing: border-box;
         background: var(--background-page);
         border-radius: 24px 24px 0 0;


### PR DESCRIPTION
now the distance to the smartphone interface is taken into account 
via env(safe-area-inset-bottom)