### PR TITLE
fix getCoinPrice render blocking

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
     <script type="text/javascript" src="src/state.js?6"></script>
     <script type="text/javascript" src="src/controllers/themeController.js?6"></script>
     <script type="text/javascript" src="src/controllers/flipTimerController.js?6"></script>
+    <script type="text/javascript" src="./src/utils.js?6"></script>
     <script type="text/javascript" src="./src/libs/preloadImages.js?6">
         preloadImages([
             '/assets/logo.svg',
@@ -54,6 +55,9 @@
 <script>
     const themeController = new ThemeController({store})
     themeController.init();
+</script>
+<script>
+    getCoinPrice();
 </script>
 <body class="hidden">
 <div class="app__container">
@@ -727,7 +731,6 @@
 <script type="text/javascript" src='./src/libs/bignumbers.js?6'></script>
 <script type="text/javascript" src="./src/analytics.js?6"></script>
 <script type="text/javascript" src="./src/controllers/localeController.js?6"></script>
-<script type="text/javascript" src="./src/utils.js?6"></script>
 <script type="text/javascript" src="./src/libs/flip-clock.js?6"></script>
 <script type="text/javascript" src="./src/lottie.js?6"></script>
 <script type="text/javascript" src="./src/mobile-menu.js?6"></script>

--- a/src/index.js
+++ b/src/index.js
@@ -358,63 +358,70 @@ const renderAuctionDomain = (domain, domainItemAddress, auctionInfo) => {
         FlipTimer.addTimer('#auction-bid-flip-clock-container', true)
     }
 
+    const auctionAmount = TonWeb.utils.fromNano(bestBidAmount)
+
+    if (previousBid !== auctionAmount) {
+        closeBidModal()
+    }
+
+    previousBid = auctionAmount
+
+
+    $('#auctionAmount').innerText = formatNumber(auctionAmount, false)
+
+    setAddress($('#auctionOwnerAddress'), bestBidAddress)
+
+    const minBet = TonWeb.utils.fromNano(
+        bestBidAmount.mul(new TonWeb.utils.BN(105)).div(new TonWeb.utils.BN(100))
+    )
+
+    $('#auctionMinBet').innerText = formatNumber(minBet, false)
+
+    const bidStep = TonWeb.utils.fromNano(
+        bestBidAmount
+            .mul(new TonWeb.utils.BN(105))
+            .div(new TonWeb.utils.BN(100))
+            .sub(bestBidAmount)
+    )
+    const bidStepToPercent = (bidStep / auctionAmount) * 100
+
+    $('#auctionBidStep').innerText = formatNumber(bidStep, false)
+    $('#auctionBidStepConverted').innerText = formatNumber(bidStepToPercent.toFixed(2))
+
+    attachBidModalListeners(domain, minBet, '#auctionBtn', domainItemAddress)
+
     getCoinPrice().then((price) => {
-        const auctionAmount = TonWeb.utils.fromNano(bestBidAmount)
-
-        if (previousBid !== auctionAmount) {
-            closeBidModal()
-        }
-
-        previousBid = auctionAmount
-
-
-        $('#auctionAmount').innerText = formatNumber(auctionAmount, false)
         if (price) {
             $('#auctionAmountConverted').innerText = formatNumber(auctionAmount * price, 2)
         }
-        setAddress($('#auctionOwnerAddress'), bestBidAddress)
-
-        const minBet = TonWeb.utils.fromNano(
-            bestBidAmount.mul(new TonWeb.utils.BN(105)).div(new TonWeb.utils.BN(100))
-        )
-
-        $('#auctionMinBet').innerText = formatNumber(minBet, false)
+       
         if (price) {
             $('#auctionMinBetConverted').innerText = formatNumber(minBet * price, 2)
         }
 
-        const bidStep = TonWeb.utils.fromNano(
-            bestBidAmount
-                .mul(new TonWeb.utils.BN(105))
-                .div(new TonWeb.utils.BN(100))
-                .sub(bestBidAmount)
-        )
-        const bidStepToPercent = (bidStep / auctionAmount) * 100
-
-        $('#auctionBidStep').innerText = formatNumber(bidStep, false)
-        $('#auctionBidStepConverted').innerText = formatNumber(bidStepToPercent.toFixed(2))
-
-        attachBidModalListeners(domain, minBet, '#auctionBtn', domainItemAddress)
     })
 }
 
-const renderFreeDomain = (domain) => {
+const renderFreeDomain = async (domain) => {
     domainType = FREE_DOMAIN_TYPE
 
-    getCoinPrice().then((price) => {
-        const salePrice = TonWeb.utils.fromNano(getMinPrice(domain))
+    const salePrice = TonWeb.utils.fromNano(getMinPrice(domain))
 
-        $('#freeMinBet').innerText = formatNumber(salePrice, false)
+    $('#freeMinBet').innerText = formatNumber(salePrice, false)
+
+    $('#bid-flip-clock-container').dataset.endDate = new Date(
+        Date.now() + getAuctionDuration() * 1000
+    ).toISOString()
+    FlipTimer.addTimer('#bid-flip-clock-container', false)
+
+    attachBidModalListeners(domain, salePrice, '#bidButton')
+
+    getCoinPrice().then((price) => {
         if (price) {
             $('#freeMinBetConverted').innerText = formatNumber(salePrice * price, 2)
         }
-
-        $('#bid-flip-clock-container').dataset.endDate = new Date(
-            Date.now() + getAuctionDuration() * 1000
-        ).toISOString()
-        FlipTimer.addTimer('#bid-flip-clock-container', false)
-
-        attachBidModalListeners(domain, salePrice, '#bidButton')
+    }).catch((e) => {
+        console.error(e)
     })
 }
 


### PR DESCRIPTION
Add first prerender fetch of coin price, by calling getCoinPrice function.
Pulled the code from "then" blocks and placed it before function call. I've left only code associated with converted price in "then" block