### PR TITLE
Placeholder improved

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
                         <label class="edit__label" for="editAdnlInput" data-locale="ton_site">
                             TON Site
                         </label>
-                        <input enterkeyhint="done" class="default__input" type="text" placeholder="ADNL address" id="editAdnlInput">
+                        <input enterkeyhint="done" class="default__input" type="text" placeholder="ADNL address (in HEX)" id="editAdnlInput">
                         <div class="edit__button">
                             <a data-locale="save" class="edit__button">Save</a>
                         </div>


### PR DESCRIPTION
While editing domain (for owner), placeholder now says that ADNL Address must be in HEX format.

This was non-obvious since storage daemon shows his adnl address in base64.