### PR TITLE
Payment modals when managing domain, updates to the "About" page contents, and minor style changes to the "My Domains" view

### DIFF
--- a/about.html
+++ b/about.html
@@ -65,27 +65,6 @@
             <input type="text" placeholder="Enter a domain" />
         </div>
         <div class="nav__controls">
-            <a id="aboutDnsLink" href="/about.html" target="_blank">
-                <button class="hover__button" id="aboutButton">
-                    <lottie-player
-                            id="aboutLottieLight"
-                            src="./assets/lottie/about_paper_light.json"
-                            background="transparent"
-                            speed="1"
-                            style="width: 24px; height: 24px;"
-                    >
-                    </lottie-player>
-                    <lottie-player
-                            id="aboutLottieDark"
-                            src="./assets/lottie/about_paper_dark.json"
-                            background="transparent"
-                            speed="1"
-                            style="width: 24px; height: 24px;"
-                    >
-                    </lottie-player>
-                    <span class="bold" data-locale="about">About</span>
-                </button>
-            </a>
             <button class="hover__button" id="lottie-button" onclick="themeController.toggle()">
                 <lottie-player id="sunLottie" src="./assets/lottie/sun_moon.json" background="transparent" speed="1" style="width: 20px; height: 20px;"></lottie-player>
                 <lottie-player id="moonLottie" src="./assets/lottie/moon_sun_light.json" background="transparent" speed="1" style="width: 20px; height: 20px;"></lottie-player>
@@ -179,7 +158,7 @@
             to avoid confusion with well-known internet domain names, such as “com”, “org”, “gov”, etc.</p>
         <p data-locale="rules_for_ton_domain_names_p2">The domain must contain English letters, digits, and hyphen.</p>
         <p class="note" data-locale="rules_for_ton_domain_names_p3">However, technically, a domain name could depict an emoji, but they’re unavailable because a lot of them look the same — e.g., 😗 and 😙 — which scammers would use to trick unsuspecting users easily.</p>
-        <p data-locale="rules_for_ton_domain_names_p4">Once per year, the domain’s owner will have to send a nanoton to the domain’s smart contract to extend the domain for a year. If the owner fails to extend their domain, it will go up for auction. Such is to prevent losing a domain forever in the event its owner loses access.</p>
+        <p data-locale="rules_for_ton_domain_names_p4">Once per year, the domain’s owner will have to send 0.015 TON to the domain’s smart contract to extend the domain for a year. If the owner fails to extend their domain, it will go up for auction. Such is to prevent losing a domain forever in the event its owner loses access.</p>
     </div>
 
     <div class="block">
@@ -230,50 +209,6 @@
             </div>
         </div>
 
-        <h3 data-locale="claim_your_ton_domain_h4">Assign your wallet address with TON Wallet extension</h3>
-        <p data-locale="claim_your_ton_domain_p6">1. Open the Google Chrome web browser on your computer.</p>
-        <p data-locale="claim_your_ton_domain_p7">2. Install the TON extension for Google Chrome by clicking on this <a target="_blank" href="https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd">link</a>.</p>
-        <p data-locale="claim_your_ton_domain_p8">3. Open the extension, click on “Import wallet”, and go to your wallet from which you were bidding and where you have your recovery phrase.</p>
-        <p data-locale="claim_your_ton_domain_p9">4. Now open your domain on <a target="_blank" href="https://dns.ton.org/">TON DNS</a> and click on “Manage your domain”.</p>
-        <p data-locale="claim_your_ton_domain_p10">5. Copy the address of your wallet, paste it into the “Wallet address” field, and click “Save”.</p>
-        <div class="image-container guide">
-            <div class="image light">
-                <div class="mobile">
-                    <img src="./assets/about/assign_wallet_light_mobile.jpg" alt="Assign wallet">
-                </div>
-                <div class="desktop">
-                    <img src="./assets/about/assign_wallet_light_desktop.jpg" alt="Assign wallet">
-                </div>
-            </div>
-            <div class="image dark">
-                <div class="mobile">
-                    <img src="./assets/about/assign_wallet_dark_mobile.jpg" alt="Assign wallet">
-                </div>
-                <div class="desktop">
-                    <img src="./assets/about/assign_wallet_dark_desktop.jpg" alt="Assign wallet">
-                </div>
-            </div>
-        </div>
-        <p data-locale="claim_your_ton_domain_p11">6. Confirm the transaction in the TON extension.</p>
-        <div class="image-container guide">
-            <div class="image light">
-                <div class="mobile">
-                    <img src="./assets/about/confirm_wallet_light_mobile.jpg" alt="Confirm the transaction">
-                </div>
-                <div class="desktop">
-                    <img src="./assets/about/confirm_wallet_light_desktop.jpg" alt="Confirm the transaction">
-                </div>
-            </div>
-            <div class="image dark">
-                <div class="mobile">
-                    <img src="./assets/about/confirm_wallet_dark_mobile.jpg" alt="Confirm the transaction">
-                </div>
-                <div class="desktop">
-                    <img src="./assets/about/confirm_wallet_dark_desktop.jpg" alt="Confirm the transaction">
-                </div>
-            </div>
-        </div>
-
         <p></p>
         <a target="_blank" class="button" href="https://ton.org/docs/participate/web3/site-management#how-to-link-a-wallet-to-a-domain">
             <span data-locale="claim_your_ton_domain_a1">Link TON Sites and subdomains</span>
@@ -314,15 +249,6 @@
         </button>
     </div>
     <div class="mobile-menu-navigation">
-        <a class="mobile-menu-row" href="/about.html" target="_blank">
-            <div class="mobile-menu-left">
-              <span class="mobile-lottie-container">
-                  <lottie-player id="aboutLottieLight" src="./assets/lottie/about_paper_light.json" background="transparent" speed="1" style="width: 24px; height: 24px;"></lottie-player>
-                  <lottie-player id="aboutLottieDark" src="./assets/lottie/about_paper_dark.json" background="transparent" speed="1" style="width: 24px; height: 24px;"></lottie-player>
-              </span>
-                <span data-locale="about">About</span>
-            </div>
-        </a>
         <div class="mobile-menu-row">
             <div class="mobile-menu-left">
               <span class="mobile-lottie-container">
@@ -344,10 +270,14 @@
 <footer class="footer">
     <div class="separator"></div>
     <div class="copyrights">
-        <div>
+        <div class="info-links">
             <a class="support-link" href="https://t.me/ton_help_bot" target="_blank" rel="noreferrer noopener">
                 <span class="support-link__icon"></span>
                 <span data-locale="footer_support">Support</span>
+            </a>
+            <a class="about-link" href="/about.html" target="_blank" rel="noreferrer noopener">
+                <span class="about-link__icon"></span>
+                <span data-locale="about">About</span>
             </a>
         </div>
         <div class="social-links">

--- a/css/dns.css
+++ b/css/dns.css
@@ -1304,10 +1304,10 @@ p {
 }
 
 .line-clamp {
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
+    word-break: break-word;
+    hyphens: auto;
+    -webkit-hyphens: auto;
+    -moz-hyphens: auto;
 }
 
 .bid__modal--qr {
@@ -1979,7 +1979,7 @@ p {
 }
 
 .edit__label {
-    padding-left: 32px;
+    padding-left: 24px;
     font-weight: 400;
     font-size: 18px;
     line-height: 28px;
@@ -2006,7 +2006,7 @@ p {
 }
 
 .edit-row-checkbox {
-    padding-left: 32px;
+    padding-left: 24px;
     margin-top: -16px;
 }
 
@@ -2852,7 +2852,7 @@ input.input__clicked {
     color: var(--text-tetriary);
 }
 
-.disabled__inpu--icon {
+.disabled__input--icon {
     fill: var(--text-tetriary);
 }
 

--- a/css/my-domains.css
+++ b/css/my-domains.css
@@ -54,22 +54,24 @@ html[data-theme='dark'] #noDomainsBannerLight {
 }
 
 .my-domains-title {
+  box-sizing: border-box;
   text-align: left;
   font-size: 28px;
   line-height: 36px;
   font-weight: 600;
   width: 100%;
-  padding: 48px 0px 0px 48px;
+  padding: 48px 0px 0px 24px;
 }
 
 .my-domains-caption {
+  box-sizing: border-box;
   text-align: left;
   font-style: normal;
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
   width: 100%;
-  padding: 0px 0px 12px 48px;
+  padding: 0px 0px 12px 24px;
 }
 
 .my-domains-table {
@@ -90,14 +92,14 @@ html[data-theme='dark'] #noDomainsBannerLight {
   cursor: default;
 }
 
-.my-domains-table-headers th:not(.my-domains-table-last-cell) {
-  width: 31%; // first three table columns
+
+.my-domains-table-headers th:not(.my-domains-table-last-column) {
+  width: 31%; /* first three table columns */
 }
 
-.my-domains-table-last-cell {
-  width: 7%; // last table column = 100% - 3 * ( 31% )
-  margin-left: auto;
-  margin-right: auto;
+
+.my-domains-table-last-column {
+  width: 7%; /* last table column = 100% - 3 * ( 31% ) */
 }
 
 .my-domains-right-arrow-icon {
@@ -311,10 +313,6 @@ html[data-theme='dark'] #noDomainsBannerLight {
     width: 16px;
     height: 16px;
     transform: translateY(10%);
-  }
-
-  .my-domains-table-last-cell {
-    width: 0%;
   }
 
   .no-domains-title {

--- a/css/my-domains.css
+++ b/css/my-domains.css
@@ -195,17 +195,32 @@ html[data-theme='dark'] #noDomainsBannerLight {
   content: '\2248\ \ $';
 }
 
-.my-domains-cell-expiry-title {
+.my-domains-cell-expiry-title-desktop {
   font-size: 16px;
   line-height: 24px;
   font-weight: 600;
 }
 
-.my-domains-cell-expiry-caption {
+.my-domains-cell-expiry-title-mobile {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 600;
+  display: none;
+}
+
+.my-domains-cell-expiry-caption-desktop {
   color: var(--text-tetriary);
   font-size: 14px;
   line-height: 18px;
   font-weight: 400;
+}
+
+.my-domains-cell-expiry-caption-mobile {
+  color: var(--text-tetriary);
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  display: none;
 }
 
 .no-domains-title {
@@ -276,14 +291,20 @@ html[data-theme='dark'] #noDomainsBannerLight {
     line-height: 16px;
   }
 
-  .my-domains-cell-expiry-title {
-    font-size: 14px;
-    line-height: 20px;
+  .my-domains-cell-expiry-title-desktop {
+    display: none;
   }
 
-  .my-domains-cell-expiry-caption {
-    font-size: 12px;
-    line-height: 16px;
+  .my-domains-cell-expiry-title-mobile {
+    display: block;
+  }
+
+  .my-domains-cell-expiry-caption-desktop {
+    display: none;
+  }
+
+  .my-domains-cell-expiry-caption-mobile {
+    display: block;
   }
 
   .my-domains-cell-price-title:before {

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
         <th data-locale="my_domains_list_domain_column">Domain</th>
         <th data-locale="my_domains_list_price_column">Sale price</th>
         <th data-locale="my_domains_list_date_column">Expires in</th>
-        <th class="my-domains-table-last-cell">&nbsp;</th>
+        <th class="my-domains-table-last-column">&nbsp;</th>
       </tr>
     </table>
     <button id="myDomainsShowMoreButton" class="btn inversed">

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
   <div id="myDomainsContainer">
     <div class="my-domains-title" data-locale="my_domains">My domains</div>
     <div class="my-domains-caption" data-locale="my_expiring_domains_caption">
-        This table includes only domains expiring in the next 360 days
+        This list includes only domains expiring in the next 360 days
     </div>
     <table class="my-domains-table">
       <tr class="my-domains-table-headers">

--- a/index.html
+++ b/index.html
@@ -617,7 +617,7 @@
             <div class="bid__modal--meta">
                 <p class="row align__center">
                     <span class="row__title" data-locale="sent_to">Sent to</span>
-                    <span id="freeBuyAddress" class="addr node__to__copy"></span>
+                    <span id="transactionAddress" class="addr node__to__copy"></span>
                     <button class="copy__addr"></button>
                 </p>
 

--- a/src/controllers/localeController.js
+++ b/src/controllers/localeController.js
@@ -105,7 +105,7 @@ const INDEX_LOCALES = {
 		claim_your_domain: 'Что такое Ton Domains?',
 		renew_this_domain: 'Продлить этот домен',
 		renew_domain: 'Продлить домен',
-		renew_domain_explanation: 'Внесите депозит, чтобы продлить ваш домен.',
+		renew_domain_explanation: 'Сделайте оплату, чтобы продлить ваш домен.',
 		use_other_payments: 'Другие способы оплаты <svg class="arrow icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">\n' +
 				'                    <path d="M16 15L11.5 10L7 15" stroke="#0088CC" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>\n' +
 				'                </svg>',
@@ -177,7 +177,7 @@ const INDEX_LOCALES = {
 		claim_your_domain: 'What is Ton Domains?',
 		renew_this_domain: 'Renew this domain',
 		renew_domain: 'Renew domain',
-		renew_domain_explanation: 'Pay a deposit to renew your domain ownership',
+		renew_domain_explanation: 'Make a payment to renew your domain ownership',
 		footer_support: 'Support',
 		wallet_connect_button: 'Connect wallet',
 		wallet_connect_button_mobile: 'Connect',

--- a/src/controllers/localeController.js
+++ b/src/controllers/localeController.js
@@ -202,7 +202,7 @@ const INDEX_LOCALES = {
 		payment_done_button: 'Done',
 		wallet_connect_mytonwallet_unknown_error: 'Please check your wallet. Try to switch network in the wallet settings.',
 		my_domains: 'My domains',
-		my_expiring_domains_caption: 'This table includes only domains expiring in the next 360 days',
+		my_expiring_domains_caption: 'This list includes only domains expiring in the next 360 days',
 		my_domains_empty_title: 'You have no expiring domains yet',
 		my_domains_empty_caption: 'Participate in the auction and buy domains.',
 		my_domains_empty_button: 'Start now',

--- a/src/controllers/localeController.js
+++ b/src/controllers/localeController.js
@@ -95,6 +95,7 @@ const INDEX_LOCALES = {
 		not_owner: 'Вы не владелец домена',
 		login_extention: 'Войдите и авторизуйтесь в расширении TON Wallet для редактирования домена',
 		invalid_address: 'Неправильный адрес',
+		invalid_adnl_address: 'Неправильный ADNL адрес',
 		install_extension: 'Установите расширение TON Wallet для управления доменом',
 		auction: 'Аукцион',
 		free: 'Свободен',
@@ -105,7 +106,7 @@ const INDEX_LOCALES = {
 		claim_your_domain: 'Что такое Ton Domains?',
 		renew_this_domain: 'Продлить этот домен',
 		renew_domain: 'Продлить домен',
-		renew_domain_explanation: 'Сделайте оплату, чтобы продлить ваш домен.',
+		renew_domain_explanation: 'Оплатите сетевую комиссию для продления домена',
 		use_other_payments: 'Другие способы оплаты <svg class="arrow icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">\n' +
 				'                    <path d="M16 15L11.5 10L7 15" stroke="#0088CC" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>\n' +
 				'                </svg>',
@@ -114,7 +115,7 @@ const INDEX_LOCALES = {
 		wallet_connect_button: 'Подключить кошелёк',
 		wallet_connect_button_mobile: 'Подключить',
 		wallet_modal_first_title: 'Подключить кошелёк',
-		wallet_modal_first_description: 'Выберете кошелёк из списка, чтобы начать работу.',
+		wallet_modal_first_description: 'Выберете кошелёк из списка, чтобы начать работу',
 		wallet_modal_first_footer: 'У вас нет кошелька?',
 		wallet_modal_first_setup: 'Установите кошелёк',
 		wallet_modal_second_title_1: 'Подключить',
@@ -155,7 +156,11 @@ const INDEX_LOCALES = {
 		manage_domain: 'Редактировать',
 		manage_domain_go_back: 'Вернуться на страницу домена',
 		manage_domain_mobile: 'Редактировать в Tonkeeper',
-		manage_domain_unavailable: 'Что-то пошло не так. Пожалуйста, повторите попытку.'
+		manage_domain_unavailable: 'Что-то пошло не так. Пожалуйста, повторите попытку.',
+		manage_domain_payment_caption: 'Редактирование настроек домена',
+		manage_domain_payment_explanation: 'Сделайте оплату для редактирования настроек домена.',
+		invalid_hex_address: 'Некорректный HEX',
+		payment_failure_alert: 'Транзакция отменена. Что-то пошло не так.',
 	},
 	en: {
 		address: 'Address',
@@ -169,6 +174,7 @@ const INDEX_LOCALES = {
 		not_owner: 'You are not the owner of this domain.',
 		login_extention: 'Open and log in to the TON Wallet extension for domain management.',
 		invalid_address: 'The address is invalid.',
+		invalid_adnl_address: 'The ADNL address is invalid.',
 		install_extension: 'Please install the TON Wallet extension to edit the domain',
 		auction: 'On auction',
 		free: 'Available',
@@ -224,7 +230,11 @@ const INDEX_LOCALES = {
 		manage_domain: 'Manage domain',
 		manage_domain_go_back: 'Go back',
 		manage_domain_mobile: 'Manage domain via Tonkeeper',
-		manage_domain_unavailable: 'Service is temporarily unavailable. Please try again.'
+		manage_domain_unavailable: 'Service is temporarily unavailable. Please try again.',
+		manage_domain_payment_caption: 'Manage domain',
+		manage_domain_payment_explanation: 'Make a payment to change domain settings.',
+		invalid_hex_address: 'The HEX field is invalid.',
+		payment_failure_alert: 'Transaction canceled. Something went wrong',
 	},
 }
 

--- a/src/controllers/localeController.js
+++ b/src/controllers/localeController.js
@@ -287,7 +287,7 @@ const ABOUT_LOCALES = {
 		rules_for_ton_domain_names_p3:
 			'Хотя технически можно было сделать доменные имена даже в виде эмоджи, они недоступны, т.к многие символы выглядят одинаково (например, 😗 и 😙), что могло бы быть использовано мошенниками.',
 		rules_for_ton_domain_names_p4:
-			'Раз в год владельцу домена требуется отправить хотя бы одну нанокопейку на смарт-контракт домена и продлить таким образом домен еще на год. Если домен не продлить, он перейдет в режим аукциона. Это сделано для того, чтобы домены не были потеряны навечно, если их владельцы каким-либо образом утратили к ним доступ.',
+			'Раз в год владельцу домена требуется отправить 0.015 TON на смарт-контракт домена и продлить таким образом домен еще на год. Если домен не продлить, он перейдет в режим аукциона. Это сделано для того, чтобы домены не были потеряны навечно, если их владельцы каким-либо образом утратили к ним доступ.',
 		decentralization: 'Децентрализация',
 		decentralization_p1:
 			'TON DNS — это децентрализованная доменная система. Не существует "администратора", который сможет заблокировать ваш домен.',
@@ -406,7 +406,7 @@ const ABOUT_LOCALES = {
 		rules_for_ton_domain_names_p3:
 			'However, technically, a domain name could depict an emoji, but they’re unavailable because a lot of them look the same — e.g., 😗 and 😙 — which scammers would use to trick unsuspecting users easily.',
 		rules_for_ton_domain_names_p4:
-			'Once per year, the domain’s owner will have to send a nanoton to the domain’s smart contract to extend the domain for a year. If the owner fails to extend their domain, it will go up for auction. Such is to prevent losing a domain forever in the event its owner loses access.',
+			'Once per year, the domain’s owner will have to send 0.015 TON to the domain’s smart contract to extend the domain for a year. If the owner fails to extend their domain, it will go up for auction. Such is to prevent losing a domain forever in the event its owner loses access.',
 		decentralization: 'Decentralization',
 		decentralization_p1:
 			'TON DNS is a decentralized domain name system. There is no “administrator” who can block your domain name.',

--- a/src/utils.js
+++ b/src/utils.js
@@ -411,6 +411,17 @@ async function getChangeDnsRecordPayload(message) {
     return payload;
 }
 
+async function getManageDomainPayload(key, value) {
+    const cell = await TonWeb.dns.DnsItem.createChangeContentEntryBody({
+        category: key,
+        value: value,
+    });
+    const cellBytes = await cell.toBoc(false);
+    const payload = TonWeb.utils.bytesToBase64(cellBytes);
+
+    return payload;
+}
+
 function openLink(href, target = '_self') {
 	window.open(href, target, 'noreferrer noopener');
 }
@@ -527,4 +538,58 @@ function getDifferenceBetweenDates(futureDate, pastDate) {
     delta -= minutes * 60;
     
     return { days, hours, minutes };
+}
+
+// modalType: 'place a bid' | 'renew' | 'manage domain'
+function adjustPaymentModalCaption(modalType) {
+    if (modalType === 'place a bid') {
+        $('#bidModalSubheader').innerText = store.localeDict.enter_amount;
+        $('#bid__modal--bid__input').classList.remove('disabled__input');
+
+        $('#bid__modal--submit__step--label_1').innerText = store.localeDict.place_label;
+        $('#bid__modal--submit__step--label_2').innerText = store.localeDict.place_label_2;
+        $('.bid__modal--payment #domainName--bid__modal--payment').innerText = store.localeDict.place_bid;
+        $('.bid__modal--second__step #domainName--bid__modal--payment').innerText = store.localeDict.place_bid;
+
+        $('#payment-message-success .payment__message--title').innerText = store.localeDict.payment_success_header;
+        $('#payment-message-success .payment__message--description').innerText = store.localeDict.payment_success_description;
+
+        $('#inputTonIcon').classList.remove('disabled__input--icon');
+
+        return;
+    }
+
+    if (modalType === 'renew') {
+        $('#bidModalSubheader').innerText = store.localeDict.renew_domain_explanation;
+        $('#bid__modal--bid__input').classList.add('disabled__input');
+
+        $('#bid__modal--submit__step--label_1').innerText = store.localeDict.pay;
+        $('#bid__modal--submit__step--label_2').innerText = '';
+        $('.bid__modal--payment #domainName--bid__modal--payment').innerText = store.localeDict.renew_domain;
+        $('.bid__modal--second__step #domainName--bid__modal--payment').innerText = store.localeDict.renew_domain;
+
+        $('#payment-message-success .payment__message--title').innerText = store.localeDict.payment_success_header;
+        $('#payment-message-success .payment__message--description').innerText = '';
+
+        $('#inputTonIcon').classList.add('disabled__input--icon');
+
+        return;
+    }
+
+    if (modalType === 'manage domain') {
+        $('#bidModalSubheader').innerText = store.localeDict.manage_domain_payment_explanation;
+        $('#bid__modal--bid__input').classList.add('disabled__input');
+
+        $('#bid__modal--submit__step--label_1').innerText = store.localeDict.pay;
+        $('#bid__modal--submit__step--label_2').innerText = '';
+        $('.bid__modal--payment #domainName--bid__modal--payment').innerText = store.localeDict.manage_domain_payment_caption;
+        $('.bid__modal--second__step #domainName--bid__modal--payment').innerText = store.localeDict.manage_domain_payment_caption;
+
+        $('#payment-message-success .payment__message--title').innerText = store.localeDict.payment_success_header;
+        $('#payment-message-success .payment__message--description').innerText = '';
+
+        $('#inputTonIcon').classList.add('disabled__input--icon');
+
+        return;
+    }
 }

--- a/src/views/myDomainsView.js
+++ b/src/views/myDomainsView.js
@@ -103,15 +103,10 @@ const buildSalePriceCell = (cell, priceInTON, priceInUSDT) => {
   cell.appendChild(priceCellDiv);
 }
 
-const buildExpiryDate = (cell, expiryDate) => {
-  cell.classList.add("my-domains-table-cell");
+const buildDesktopSpanPriceInTON = (node, { days, hours, minutes }) => {
+  const desktopSpanPriceInTON = document.createElement('span');
+  desktopSpanPriceInTON.classList.add('my-domains-cell-expiry-title-desktop');
 
-  const priceCellDiv = document.createElement('div');
-  priceCellDiv.classList.add('my-domains-cell-container');
-
-  const spanPriceInTON = document.createElement('span');
-  spanPriceInTON.classList.add('my-domains-cell-expiry-title');
-  const { days, hours, minutes } = getDifferenceBetweenDates(expiryDate, new Date());
   let dayStr = '';
   if (days === 1) {
     dayStr = `1 ${store.localeDict.day} `;
@@ -119,17 +114,55 @@ const buildExpiryDate = (cell, expiryDate) => {
   if(days > 1){
     dayStr = `${days} ${store.localeDict.days} `;
   }
-  if (isMobile() && days === 0) {
-    dayStr = store.localeDict.today;
-  }
-  spanPriceInTON.innerText = isMobile() ?
-    dayStr : `${dayStr} ${hours} ${store.localeDict.hours} ${minutes} ${store.localeDict.min}`;
-  priceCellDiv.appendChild(spanPriceInTON);
 
-  const spanPriceInUSDT = document.createElement('span');
-  spanPriceInUSDT.classList.add("my-domains-cell-expiry-caption");
-  spanPriceInUSDT.innerText = isMobile() ? formatDateShort(expiryDate) : formatDate(expiryDate); 
-  priceCellDiv.appendChild(spanPriceInUSDT);
+  desktopSpanPriceInTON.innerHTML = `${dayStr} ${hours} ${store.localeDict.hours} ${minutes} ${store.localeDict.min}`;
+  node.appendChild(desktopSpanPriceInTON);
+}
+
+const buildMobileSpanPriceInTON = (node, { days }) => {
+  const mobileSpanPriceInTON = document.createElement('span');
+  mobileSpanPriceInTON.classList.add('my-domains-cell-expiry-title-mobile');
+
+  let dayStr = '';
+  if (days === 1) {
+    dayStr = `1 ${store.localeDict.day} `;
+  }
+  if(days > 1){
+    dayStr = `${days} ${store.localeDict.days} `;
+  }
+
+  mobileSpanPriceInTON.innerHTML = days === 0 ? store.localeDict.today : dayStr;
+  node.appendChild(mobileSpanPriceInTON);
+}
+
+const buildDesktopSpanPriceInUSDT = (node, expiryDate) => {
+  const desktopSpanPriceInUSDT = document.createElement('span');
+  desktopSpanPriceInUSDT.classList.add("my-domains-cell-expiry-caption-desktop");
+
+  desktopSpanPriceInUSDT.innerText = formatDate(expiryDate); 
+  node.appendChild(desktopSpanPriceInUSDT);
+}
+
+const buildMobileSpanPriceInUSDT = (node, expiryDate) => {
+  const mobileSpanPriceInUSDT = document.createElement('span');
+  mobileSpanPriceInUSDT.classList.add("my-domains-cell-expiry-caption-mobile");
+
+  mobileSpanPriceInUSDT.innerText = formatDateShort(expiryDate); 
+  node.appendChild(mobileSpanPriceInUSDT);
+}
+
+const buildExpiryDate = (cell, expiryDate) => {
+  cell.classList.add("my-domains-table-cell");
+
+  const priceCellDiv = document.createElement('div');
+  priceCellDiv.classList.add('my-domains-cell-container');
+
+  const datetime = getDifferenceBetweenDates(expiryDate, new Date());
+  buildDesktopSpanPriceInTON(priceCellDiv, datetime);
+  buildMobileSpanPriceInTON(priceCellDiv, datetime);
+
+  buildDesktopSpanPriceInUSDT(priceCellDiv, expiryDate);
+  buildMobileSpanPriceInUSDT(priceCellDiv, expiryDate);
 
   cell.appendChild(priceCellDiv);
 }

--- a/src/views/myDomainsView.js
+++ b/src/views/myDomainsView.js
@@ -170,7 +170,6 @@ const buildExpiryDate = (cell, expiryDate) => {
 const buildArrowRight = (cell) => {
   cell.classList.add("my-domains-table-cell-last");
 
-  cell.classList.add('my-domains-table-last-cell');
   const rightChevronLottie = document.createElement('span');
   rightChevronLottie.classList.add('my-domains-right-arrow-icon');
   cell.appendChild(rightChevronLottie);


### PR DESCRIPTION
- Implemented payment modals on the "Manage domain" page
- "About" page:
  - Removed part regarding the Ton Wallet extension
  - Updated the price of the domain renewal (mentioned in the text)
- Added a dynamic date format change (for the expiry date column) when resizing the screen
- Resolved issue with appearing bottom scroll because of the caption ('my domains' page)

Before: [screen-capture-styles-before.webm](https://github.com/ton-blockchain/dns/assets/20891090/5391e36f-ebad-4b3d-bb90-187e31e8e35d)
After: [screen-capture-styles-after.webm](https://github.com/ton-blockchain/dns/assets/20891090/f19c85fb-5e62-4619-8632-435e045c6a04)


